### PR TITLE
이력서 페이지 폰트 수정 및 사이드 프로젝트 섹션명 변경

### DIFF
--- a/_content/resume.md
+++ b/_content/resume.md
@@ -49,7 +49,7 @@ updatedAt: "2026-04-19"
 - C-JeS Entertainment Website 리뉴얼
 - 대검찰청 모바일 웹사이트 구축
 
-## 오픈소스
+## 사이드 프로젝트
 
 ### [hotwatermat-ble](https://github.com/minjun0219/hotwatermat-ble)
 

--- a/app/resume/page.module.css
+++ b/app/resume/page.module.css
@@ -5,6 +5,7 @@
 
 .article {
   font-family: var(--font-family-base);
+  font-size: 1rem;
   line-height: 1.7;
 }
 

--- a/app/resume/page.module.css
+++ b/app/resume/page.module.css
@@ -4,6 +4,7 @@
 }
 
 .article {
+  font-family: var(--font-family-base);
   line-height: 1.7;
 }
 


### PR DESCRIPTION
## Summary

- `/resume` 페이지가 크롬에서 한글 본문을 명조체(serif)로 렌더링하던 문제를 수정합니다. `app/globals.css`의 body 폰트 체인이 `Nunito, ..., monospace, serif`로 끝나는데 Nunito가 한글 글리프를 제공하지 않아 fallback이 `serif`까지 떨어지고 있었습니다. 블로그는 `PostArticle.module.css`에서 `--font-family-base`로 덮어쓰고 있었지만, 이력서 페이지는 `PostContent`를 직접 사용해 해당 override가 없었습니다.
- `app/resume/page.module.css`의 `.article`에 `font-family: var(--font-family-base);`를 추가하여 블로그와 동일한 시스템 sans-serif 스택을 적용했습니다.
- `_content/resume.md`의 `## 오픈소스` 섹션 제목을 `## 사이드 프로젝트`로 변경했습니다.

## Test plan

- [ ] 크롬에서 `/resume` 방문 — 한글 본문이 sans-serif로 렌더링되는지 확인
- [ ] 라이트/다크 테마 토글 시에도 폰트가 유지되는지 확인
- [ ] "사이드 프로젝트" 섹션 제목이 올바르게 표기되는지 확인
- [ ] 블로그 포스트(`/posts/...`)에서 폰트 회귀가 없는지 교차 확인

https://claude.ai/code/session_01DgxEi8qthPXZ3ir6rjMsgQ