### PR TITLE
RSS 피드 경로를 /feed.xml에서 /posts/feed.xml로 이동

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,9 @@ export const metadata: Metadata = {
   publisher: AUTHOR_NAME,
   alternates: {
     types: {
-      "application/rss+xml": [{ url: "/feed.xml", title: `${SITE_NAME} RSS` }],
+      "application/rss+xml": [
+        { url: "/posts/feed.xml", title: `${SITE_NAME} RSS` },
+      ],
     },
   },
   openGraph: {

--- a/app/posts/feed.xml/route.ts
+++ b/app/posts/feed.xml/route.ts
@@ -64,7 +64,7 @@ export async function GET() {
     "<channel>",
     `<title>${escapeXml(SITE_NAME)}</title>`,
     `<link>${escapeXml(SITE_URL)}</link>`,
-    `<atom:link href="${escapeXml(`${SITE_URL}/feed.xml`)}" rel="self" type="application/rss+xml" />`,
+    `<atom:link href="${escapeXml(`${SITE_URL}/posts/feed.xml`)}" rel="self" type="application/rss+xml" />`,
     `<description>${escapeXml(SITE_DESCRIPTION)}</description>`,
     "<language>ko</language>",
     `<lastBuildDate>${lastBuildDate}</lastBuildDate>`,

--- a/src/containers/Posts/Posts.tsx
+++ b/src/containers/Posts/Posts.tsx
@@ -55,7 +55,7 @@ const Posts = () => {
       />
       <footer className={styles.footer}>
         <a
-          href="/feed.xml"
+          href="/posts/feed.xml"
           className={styles.feedLink}
           aria-label="RSS 피드 구독"
         >


### PR DESCRIPTION
## Summary
- RSS 피드 라우트를 `app/feed.xml/route.ts`에서 `app/posts/feed.xml/route.ts`로 이동하여 `/posts/feed.xml`로 서비스되도록 변경
- 피드는 블로그 포스트만 제공하므로 URL 구조상 `/posts` 하위가 더 자연스러움
- 메타데이터의 `alternates.types["application/rss+xml"]`와 Posts 컨테이너의 Feed 링크, 응답 XML 내 `atom:link` self URL을 모두 새 경로로 갱신
- 리다이렉트 없이 단순 이동 (사용자 선택)

## Test plan
- [ ] `pnpm dev` 후 `http://localhost:3000/posts/feed.xml` 접근 시 RSS XML이 정상 응답되는지 확인
- [ ] `http://localhost:3000/feed.xml` 접근 시 404가 반환되는지 확인 (의도된 동작)
- [ ] `/posts` 페이지의 "Feed" 푸터 링크가 `/posts/feed.xml`로 연결되는지 확인
- [ ] 페이지 `<head>`의 `<link rel="alternate" type="application/rss+xml">` href가 `/posts/feed.xml`을 가리키는지 확인
- [ ] 응답된 XML의 `<atom:link rel="self">` href가 `${SITE_URL}/posts/feed.xml`인지 확인
- [ ] `pnpm build` 성공 확인

https://claude.ai/code/session_01VNSc2QfkVMkcyxT6xeZAai

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNSc2QfkVMkcyxT6xeZAai)_