### PR TITLE
옛 underfront 글 /archives/31 리다이렉트 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,11 @@ const nextConfig = {
         destination: "/posts/next-js-wp-graphql-static-blog",
         permanent: true,
       },
+      {
+        source: "/archives/31",
+        destination: "/posts/frontend-development-and-web-publishing",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
## 변경 사항

WordPress(underfront.com) 시절의 퍼머링크 `/archives/31`을 복원된 원본 글로 영구 리다이렉트(308)하도록 `next.config.mjs`에 추가했습니다.

- `/archives/31` → `/posts/frontend-development-and-web-publishing` (프론트엔드 개발, 그리고 웹 퍼블리싱)

기존 `http://www.underfront.com/archives/31` → `https://minjun.kim/archives/31` 리다이렉트(외부에서 처리됨)가 그동안 404로 끝나던 것을, 이제 사이트 내에서 원본 글로 이어지도록 마무리합니다.

## 검증
- `next build` 컴파일 성공 (redirects 설정 정상 적용)

## 참고
같은 패턴의 옛 글(`/archives/{id}`)이 더 있다면 한 번에 매핑을 추가할 수 있습니다.

https://claude.ai/code/session_018d7NS4btWPyJJDS4cQCnFe

---
_Generated by [Claude Code](https://claude.ai/code/session_018d7NS4btWPyJJDS4cQCnFe)_