### PR TITLE
옛 underfront WordPress 아카이브 퍼머링크 일괄 리다이렉트

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,6 +19,11 @@ const nextConfig = {
         destination: "/posts/voiceover-on-mac-os-x-lion",
         permanent: true,
       },
+      {
+        source: "/archives/706",
+        destination: "/posts/voiceover-on-mac-os-x-lion",
+        permanent: true,
+      },
     ];
   },
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,14 +9,26 @@ const nextConfig = {
         destination: "/posts/next-js-wp-graphql-static-blog",
         permanent: true,
       },
+      // 옛 underfront.com WordPress 아카이브 퍼머링크 → 복원된 글
+      // /archives/:id, /wp/archives/:id, /blog/archives/:id 를 모두 매칭
       {
-        source: "/:wp(wp)?/archives/31",
+        source: "/:prefix(wp|blog)?/archives/31",
         destination: "/posts/frontend-development-and-web-publishing",
         permanent: true,
       },
       {
-        source: "/:wp(wp)?/archives/706",
+        source: "/:prefix(wp|blog)?/archives/:id(40|706)",
         destination: "/posts/voiceover-on-mac-os-x-lion",
+        permanent: true,
+      },
+      {
+        source: "/:prefix(wp|blog)?/archives/302",
+        destination: "/posts/1px-on-retina-display",
+        permanent: true,
+      },
+      {
+        source: "/:prefix(wp|blog)?/archives/330",
+        destination: "/posts/flava-clipper-postmortem",
         permanent: true,
       },
     ];

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,11 @@ const nextConfig = {
         destination: "/posts/frontend-development-and-web-publishing",
         permanent: true,
       },
+      {
+        source: "/wp/archives/706",
+        destination: "/posts/voiceover-on-mac-os-x-lion",
+        permanent: true,
+      },
     ];
   },
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,17 +10,12 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: "/archives/31",
+        source: "/:wp(wp)?/archives/31",
         destination: "/posts/frontend-development-and-web-publishing",
         permanent: true,
       },
       {
-        source: "/wp/archives/706",
-        destination: "/posts/voiceover-on-mac-os-x-lion",
-        permanent: true,
-      },
-      {
-        source: "/archives/706",
+        source: "/:wp(wp)?/archives/706",
         destination: "/posts/voiceover-on-mac-os-x-lion",
         permanent: true,
       },


### PR DESCRIPTION
## 변경 사항

옛 underfront.com WordPress 아카이브 퍼머링크를 복원된 글로 영구 리다이렉트(308)합니다. 기존 Netlify `_redirects`의 post_id 매핑을 참고해 정리했습니다.

`source`의 `:prefix(wp|blog)?` 옵션 파라미터로 **`/archives/:id`, `/wp/archives/:id`, `/blog/archives/:id` 세 경로 형태를 한 규칙으로** 매칭하고, 같은 글의 여러 id는 `:id(40|706)`처럼 묶어 **글당 한 줄**로 통합했습니다.

```js
{ source: "/:prefix(wp|blog)?/archives/31",         destination: "/posts/frontend-development-and-web-publishing" },
{ source: "/:prefix(wp|blog)?/archives/:id(40|706)", destination: "/posts/voiceover-on-mac-os-x-lion" },
{ source: "/:prefix(wp|blog)?/archives/302",        destination: "/posts/1px-on-retina-display" },
{ source: "/:prefix(wp|blog)?/archives/330",        destination: "/posts/flava-clipper-postmortem" },
```

| post_id | 글 | 목적지 |
| --- | --- | --- |
| 31 | 프론트엔드 개발, 그리고 웹 퍼블리싱 | `/posts/frontend-development-and-web-publishing` |
| 40, 706 | Mac OS X Lion에서 VoiceOver 사용하기 | `/posts/voiceover-on-mac-os-x-lion` |
| 302 | Retina Display에서 1px을 1px로 보이게 하는 법 | `/posts/1px-on-retina-display` |
| 330 | 플라바 클리퍼 제작 후기 | `/posts/flava-clipper-postmortem` |

> 아카이브 ID마다 글이 다르므로 전부를 한 규칙으로 합칠 수는 없고, 경로 접두사 중복과 동일 글의 복수 id만 통합했습니다. 4줄로 5개 id × 3가지 접두사 = 15개 URL 패턴을 커버합니다.

### 쿼리스트링 보존
Next.js `redirects()`는 destination에 별도 쿼리가 없으면 들어온 쿼리스트링을 그대로 전달합니다. 미사용 `:prefix`/`:id` 파라미터가 쿼리로 붙지 않는 것도 확인했습니다.

## 검증 (`next start` 로컬 실측)
- 15개 URL 패턴(4글 × 접두사 없음/`wp`/`blog`, VoiceOver는 40·706) 모두 308 정상 리다이렉트
- `?utm_source=…&utm_medium=…&utm_campaign=…` location에 그대로 보존
- `/archives/999` → 404 (오매칭 없음), `/xx/archives/31` → 404 (`wp`/`blog` 접두사만 허용)
- 쿼리 오염(`?prefix=` / `?id=`) 없음
- `next build` 컴파일 성공

https://claude.ai/code/session_018d7NS4btWPyJJDS4cQCnFe