### PR TITLE
커스텀 404 페이지 추가 (홈으로 돌아가기 링크)

### DIFF
--- a/app/not-found.module.css
+++ b/app/not-found.module.css
@@ -1,5 +1,9 @@
 .container {
-  padding: 5em 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: calc(100vh - 14rem);
+  padding: 3em 0;
   font-family: var(--font-family-base);
   color: var(--text-color);
 }

--- a/app/not-found.module.css
+++ b/app/not-found.module.css
@@ -3,7 +3,8 @@
   flex-direction: column;
   justify-content: center;
   min-height: calc(100vh - 14rem);
-  padding: 3em 0;
+  padding-top: 3em;
+  padding-bottom: 3em;
   font-family: var(--font-family-base);
   color: var(--text-color);
 }

--- a/app/not-found.module.css
+++ b/app/not-found.module.css
@@ -1,67 +1,39 @@
 .container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  padding: 6em 0;
+  padding: 5em 0;
+  font-family: var(--font-family-base);
   color: var(--text-color);
 }
 
 .code {
-  margin: 0;
-  font-size: 5rem;
-  font-weight: 800;
-  line-height: 1;
-  color: var(--primary-color);
+  margin: 0 0 0.75em;
+  font-size: 0.8rem;
+  letter-spacing: 0.15em;
+  color: var(--text-secondary-color);
 }
 
 .title {
-  margin: 0.5em 0 0;
-  font-size: 1.5rem;
-  font-weight: 700;
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 800;
+  line-height: 1.4;
   word-break: keep-all;
 }
 
 .description {
-  margin: 1em 0 2em;
+  margin: 0.75em 0 2em;
   color: var(--text-secondary-color);
   word-break: keep-all;
 }
 
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.75em;
-}
-
-.homeLink,
-.subLink {
-  display: inline-block;
-  padding: 0.6em 1.2em;
-  border-radius: 6px;
-  font-weight: 600;
+.home:link,
+.home:visited {
+  color: var(--text-secondary-color);
   text-decoration: none;
-  transition-property: opacity, background, color;
-  transition-duration: var(--transition-duration);
+  transition: color 0.3s;
 }
 
-.homeLink {
-  background: var(--primary-color);
-  color: var(--background-color);
-}
-
-.homeLink:hover,
-.homeLink:focus {
-  opacity: 0.85;
-}
-
-.subLink {
+.home:hover,
+.home:focus {
   color: var(--text-color);
-  border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
-}
-
-.subLink:hover,
-.subLink:focus {
-  background: var(--code-highlight-color);
+  text-decoration: underline;
 }

--- a/app/not-found.module.css
+++ b/app/not-found.module.css
@@ -1,0 +1,67 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 6em 0;
+  color: var(--text-color);
+}
+
+.code {
+  margin: 0;
+  font-size: 5rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--primary-color);
+}
+
+.title {
+  margin: 0.5em 0 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  word-break: keep-all;
+}
+
+.description {
+  margin: 1em 0 2em;
+  color: var(--text-secondary-color);
+  word-break: keep-all;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75em;
+}
+
+.homeLink,
+.subLink {
+  display: inline-block;
+  padding: 0.6em 1.2em;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+  transition-property: opacity, background, color;
+  transition-duration: var(--transition-duration);
+}
+
+.homeLink {
+  background: var(--primary-color);
+  color: var(--background-color);
+}
+
+.homeLink:hover,
+.homeLink:focus {
+  opacity: 0.85;
+}
+
+.subLink {
+  color: var(--text-color);
+  border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+}
+
+.subLink:hover,
+.subLink:focus {
+  background: var(--code-highlight-color);
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import Layout from "@/components/Layout";
+import Wrapper from "@/components/Wrapper";
+
+import styles from "./not-found.module.css";
+
+export const metadata: Metadata = {
+  title: "페이지를 찾을 수 없습니다 (404)",
+  robots: { index: false, follow: false },
+};
+
+export default function NotFound() {
+  return (
+    <Layout>
+      <Wrapper className={styles.container}>
+        <p className={styles.code}>404</p>
+        <h1 className={styles.title}>페이지를 찾을 수 없습니다</h1>
+        <p className={styles.description}>
+          요청하신 페이지가 이동되었거나 더 이상 존재하지 않습니다.
+        </p>
+        <div className={styles.actions}>
+          <Link href="/" className={styles.homeLink}>
+            홈으로 돌아가기
+          </Link>
+          <Link href="/posts" className={styles.subLink}>
+            글 목록 보기
+          </Link>
+        </div>
+      </Wrapper>
+    </Layout>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -20,14 +20,9 @@ export default function NotFound() {
         <p className={styles.description}>
           요청하신 페이지가 이동되었거나 더 이상 존재하지 않습니다.
         </p>
-        <div className={styles.actions}>
-          <Link href="/" className={styles.homeLink}>
-            홈으로 돌아가기
-          </Link>
-          <Link href="/posts" className={styles.subLink}>
-            글 목록 보기
-          </Link>
-        </div>
+        <Link href="/" className={styles.home}>
+          ← 홈으로 돌아가기
+        </Link>
       </Wrapper>
     </Layout>
   );


### PR DESCRIPTION
## 변경 사항

Next.js 기본 not-found 화면 대신 사이트 레이아웃을 적용한 **커스텀 404 페이지**(`app/not-found.tsx`)를 추가했습니다.

- `Layout`(Header + Footer)으로 감싸 헤더 로고(홈 링크)·테마 토글 등 사이트 내비게이션 유지
- 본문은 사이트 미니멀 톤에 맞춰 muted 텍스트로 구성: 작은 `404` 라벨 + 절제된 제목 + 회색 안내문 + **"← 홈으로 돌아가기"**(`/`) 텍스트 링크
- 콘텐츠를 세로 중앙 정렬(`min-height: calc(100vh - 14rem)`)하고 `Wrapper`의 좌우 패딩 유지
- 고유 타이틀 `페이지를 찾을 수 없습니다 (404)` + `robots: noindex, nofollow`

> 헤더 로고도 홈 링크라, 본문 링크와 함께 두 경로로 홈 진입이 가능합니다. (초기안의 `/posts` 보조 링크는 미니멀 톤 정리 과정에서 제거)

## 검증 (`next start` 로컬 실측)
- 두 진입 경로(루트 unmatched, `dynamicParams=false`인 `/posts/unknown`) 모두 **HTTP 404 + 단일 title** `페이지를 찾을 수 없습니다 (404) | minjun.kim`
- 홈 링크(`href="/"`) 렌더 확인, 좌우 패딩(16px) 유지 확인
- `next build` 컴파일 성공, `biome check` 통과

## PostHog 대시보드 연동
404 페이지 document title이 기존 Next.js 기본값(`"404: This page could not be found."`)에서 위 새 타이틀로 바뀝니다. 그에 맞춰 "404 / 옛 링크 모니터링" 대시보드 인사이트 3종 필터를 **기존 타이틀 + 새 타이틀 둘 다 매칭**하도록 이미 업데이트했습니다.

https://claude.ai/code/session_018d7NS4btWPyJJDS4cQCnFe